### PR TITLE
Added instructions for building project in the llvm-project repo to R…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_subdirectory(toy)
+add_subdirectory(btorProject)

--- a/README.md
+++ b/README.md
@@ -3,3 +3,28 @@
 Build the MLIR repo using the instructions in https://mlir.llvm.org/getting_started/. You'll get a folder `llvm-project`.
 
 Clone this repo into `llvm-project/mlir/examples/`. Erase the contents of `llvm-project/mlir/examples/CMakeLists.txt` and replace it with one line: `add_subdirectory(btor2mlir)`. This will let cmake compile the toy folder in our repo instead of the default toy folder. 
+
+As an interim way of building btor2mlir files within the MLIR repo, open `llvm-project/mlir/test/CMakeLists.txt` and find the following section:
+
+```
+if(LLVM_BUILD_EXAMPLES)
+  list(APPEND MLIR_TEST_DEPENDS
+    toyc-ch1
+    ...
+  )
+endif()
+```
+
+Append the executable name `btor2mlir` to the `list()`. The changed section should look like:
+
+```
+if(LLVM_BUILD_EXAMPLES)
+  list(APPEND MLIR_TEST_DEPENDS
+    toyc-ch1
+    ...
+    btor2mlir
+  )
+endif()
+```
+
+You can now build the `llvm-project` repo again and run the `btor2mlir` executable file in `llvm-project/build/bin`.

--- a/btorProject/CMakeLists.txt
+++ b/btorProject/CMakeLists.txt
@@ -1,0 +1,11 @@
+set(LLVM_LINK_COMPONENTS
+  Support
+  )
+
+add_executable(btor2mlir btor2exe.cpp)
+
+include_directories(include/)
+target_link_libraries(btor2mlir
+  PRIVATE
+    MLIRSupport)
+

--- a/btorProject/btor2exe.cpp
+++ b/btorProject/btor2exe.cpp
@@ -1,0 +1,6 @@
+#include <iostream>
+
+int main(int argc, char** argv) {
+    std::cout << "Hello World"; 
+    return 0;
+}


### PR DESCRIPTION
…EADME. New 'Hello World' executable in btor2exe.cpp is compiled to llvm-project repo's build/bin.

If you change the CMakeList.txt files listed in the README and build the project again, you'll set up the project to also compile our btor2exe.cpp file. It's a hack solution, to be sure, but we can worry about proper build pipelines later.